### PR TITLE
Send test post to verify that the automation works

### DIFF
--- a/records/new/post.json
+++ b/records/new/post.json
@@ -1,0 +1,5 @@
+{
+  "action": "post",
+  "account": "NODEJS_ORG",
+  "richText": "We are testing collaborative Bluesky content management. This post is sent from a GitHub action triggered by a merged pull request in https://github.com/nodejs/bluesky/pull/7!"
+}

--- a/review_guidelines.md
+++ b/review_guidelines.md
@@ -5,3 +5,4 @@ The review guidelines are currently under discussions.
 Currently, only the following automated Bluesky content is allowed:
 
 - Posting of release announcements, or reposts of release announcements posted by releasers.
+- Posts used to verify the automation itself, if considered appropriate.


### PR DESCRIPTION
Reopened from https://github.com/nodejs/bluesky/pull/5 from a branch in this repository, because turns out secrets are not available to workflows started from forks (duh), and we should do a bit of follow-up to split the validation into full validation (validates bluesky URL references which requires secrets) + local validation (just that the JSON looks right, without requiring secrets) as mentioned in https://github.com/nodejs/bluesky/pull/5#issuecomment-2510283183 