### PR TITLE
fix: allow deletion of PR branch

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,7 +1,8 @@
 name: Process newly added JSON
 
 on:
-  push:
+  pull_request_target:
+    types: [closed]
     branches:
       - main
 
@@ -14,18 +15,17 @@ concurrency:
 
 jobs:
   process-json:
+    # Only run if the PR was merged
+    if: github.event.pull_request.merged == true
+
     runs-on: ubuntu-latest
 
     steps:
-      - name: Compute number of pushed commits
-        id: nb-of-commits
-        run: |
-          echo "plusOne=$((${{ github.event.commits.added.length }} + 1))" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ steps.nb-of-commits.outputs.plusOne }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 2
 
       # Must be done before setup-node.
       - name: Enable Corepack
@@ -46,7 +46,7 @@ jobs:
         id: find-json
         run: |
           # Get the list of added JSON files in the records/new/ directory
-          ADDED_FILES=$(git diff HEAD~${{ steps.nb-of-commits.outputs.plusOne }} --diff-filter=A --name-only records/new | grep '/.*\.json$' || true)
+          ADDED_FILES=$(git diff HEAD^ --diff-filter=A --name-only records/new | grep '/.*\.json$' || true)
           echo "NEW_JSON_FILES=$ADDED_FILES" >> "$GITHUB_ENV"
 
       - name: Process and move files
@@ -59,15 +59,6 @@ jobs:
             echo "Processing $file..."
             node actions/process.js "$file"
           done
-      - name: Generate commit message
-        run: |
-          COMMIT_MESSAGE="Process new JSON files"
-          if [ "${{ steps.nb-of-commits.outputs.plusOne }}" = "2" ] && git log --format=%s -1 | grep -q ' (#[[:digit]]+)$'; then
-            LAST_COMMIT_MESSAGE="$(git log --format=%s -1)"
-            PR_ID="(${LAST_COMMIT_MESSAGE#*\(\#}"
-            COMMIT_MESSAGE="${COMMIT_MESSAGE} from #${PR_ID:1:-1}"
-          fi
-          echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_ENV"
 
       - name: Commit and push changes
         if: env.NEW_JSON_FILES
@@ -75,5 +66,5 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add records/
-          git commit -m "$COMMIT_MESSAGE"
+          git commit -m "Process new JSON files from #${{ github.event.pull_request.number }}" || exit 0
           git push

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Compute number of pushed commits
         id: nb-of-commits
         run: |
-          echo "plusOne=$((${{ github.event.commits.added.length }} + 1))" >> $GITHUB_OUTPUT
+          echo "plusOne=$((${{ github.event.commits.added.length }} + 1))" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -67,4 +67,4 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add records/
           git commit -m "Process new JSON files from #${{ github.event.pull_request.number }}" || exit 0
-          git push origin HEAD:main
+          git push origin HEAD:refs/heads/main

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -67,4 +67,4 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add records/
           git commit -m "Process new JSON files from #${{ github.event.pull_request.number }}" || exit 0
-          git push
+          git push origin HEAD:main

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,8 +1,7 @@
 name: Process newly added JSON
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
@@ -15,17 +14,18 @@ concurrency:
 
 jobs:
   process-json:
-    # Only run if the PR was merged
-    if: github.event.pull_request.merged == true
-
     runs-on: ubuntu-latest
 
     steps:
+      - name: Compute number of pushed commits
+        id: nb-of-commits
+        run: |
+          echo "plusOne=$((${{ github.event.commits.added.length }} + 1))" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Needed to push changes back to the repo
-          fetch-depth: 0
+          fetch-depth: ${{ steps.nb-of-commits.outputs.plusOne }}
 
       # Must be done before setup-node.
       - name: Enable Corepack
@@ -46,11 +46,8 @@ jobs:
         id: find-json
         run: |
           # Get the list of added JSON files in the records/new/ directory
-          ADDED_FILES=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} --diff-filter=A --name-only | grep '^records/new/.*\.json$' || true)
-          echo "NEW_JSON_FILES=$ADDED_FILES" >> $GITHUB_ENV
-          if [ -z "$ADDED_FILES" ]; then
-            echo "No new JSON files found."
-          fi
+          ADDED_FILES=$(git diff HEAD~${{ steps.nb-of-commits.outputs.plusOne }} --diff-filter=A --name-only records/new | grep '/.*\.json$' || true)
+          echo "NEW_JSON_FILES=$ADDED_FILES" >> "$GITHUB_ENV"
 
       - name: Process and move files
         if: env.NEW_JSON_FILES
@@ -62,12 +59,21 @@ jobs:
             echo "Processing $file..."
             node actions/process.js "$file"
           done
+      - name: Generate commit message
+        run: |
+          COMMIT_MESSAGE="Process new JSON files"
+          if [ "${{ steps.nb-of-commits.outputs.plusOne }}" = "2" ] && git log --format=%s -1 | grep -q ' (#[[:digit]]+)$'; then
+            LAST_COMMIT_MESSAGE="$(git log --format=%s -1)"
+            PR_ID="(${LAST_COMMIT_MESSAGE#*\(\#}"
+            COMMIT_MESSAGE="${COMMIT_MESSAGE} from #${PR_ID:1:-1}"
+          fi
+          echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_ENV"
 
       - name: Commit and push changes
         if: env.NEW_JSON_FILES
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add records/*
-          git commit -m "Process new JSON files from #${{ github.event.pull_request.number }}" || exit 0
+          git add records/
+          git commit -m "$COMMIT_MESSAGE"
           git push

--- a/automation.md
+++ b/automation.md
@@ -46,7 +46,7 @@ Content automation is done in the form of adding new JSON files to `records/new`
    - For other fields see the examples under [`records/new`](./records/new).
 3. When the PR is opened, the [validate-json](./.github/workflows/validate.yml) workflow will run to make sure the JSON files are correctly filled. It will verify the URLs filled in the JSON files are valid.
 4. When the PR is merged, the [process-json](./.github/workflows/process.yml) workflow will run to perform the requested actions, and when it's done, it will move the processed JSON files to `./records/processed` and renamed the file to `YYYY-MM-DD-ID.json` where ID is an incremental ID based on the number of files already processed on that date. It will also add in additional details of the performed actions (e.g. CID and URI of the posted post).
-5. When the process workflow is complete (likely within a minute), you should see a commit from the GitHub bot in the main branch moving the JSON file. **Important**: do not delete the PR branch until the process workflow is complete!
+5. When the process workflow is complete (likely within a minute), you should see a commit from the GitHub bot in the main branch moving the JSON file.
 
 ## Set up automation in a repository
 

--- a/automation.md
+++ b/automation.md
@@ -45,7 +45,7 @@ Content automation is done in the form of adding new JSON files to `records/new`
      - `"quote-post"`: quote an existing post specified by `"repostURL"`, with new content specified by `"richText"`
    - For other fields see the examples under [`records/new`](./records/new).
 3. When the PR is opened, the [validate-json](./.github/workflows/validate.yml) workflow will run to make sure the JSON files are correctly filled. It will verify the URLs filled in the JSON files are valid.
-4. When the PR is merged, the [process-json](./.github/workflows/process.yml) workflow will run to perform the requested actions, and when it's done, it will move the processed JSON files to `./records/processed` and renamed the file to `YYYY-MM-DD-ID.json` where ID is an incremental ID based on the number of files already processed on that date. It will also add in additional details of the performed actions (e.g. CID and URI of the posted post).
+4. When the PR is merged (either with _Squash and merge_ or with a merge commit, _Rebase and merge_ is not supported), the [process-json](./.github/workflows/process.yml) workflow will run to perform the requested actions, and when it's done, it will move the processed JSON files to `./records/processed` and renamed the file to `YYYY-MM-DD-ID.json` where ID is an incremental ID based on the number of files already processed on that date. It will also add in additional details of the performed actions (e.g. CID and URI of the posted post).
 5. When the process workflow is complete (likely within a minute), you should see a commit from the GitHub bot in the main branch moving the JSON file.
 
 ## Set up automation in a repository


### PR DESCRIPTION
By using the `push` event instead of the `pull_request` event, we can no longer care about whether the head branch gets deleted or not.