### PR TITLE
use GraphQL call instead of `git push`

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -64,12 +64,13 @@ jobs:
       - name: Commit and push changes
         if: env.NEW_JSON_FILES
         run: |
+          git add records/
           node actions/lib/createCommitOnBranch.mjs \
             "$GITHUB_REPOSITORY" \
             "main" \
             "$(git rev-parse HEAD)" \
-            "$(git diff --diff-filter=d --name-only --format=)" \
-            "$(git diff --diff-filter=D --name-only --format=)" \
+            "$(git diff HEAD --diff-filter=d --name-only --format=)" \
+            "$(git diff HEAD --diff-filter=D --name-only --format=)" \
             "Process new JSON files from #${{ github.event.pull_request.number }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 2
+          persist-credentials: false
 
       # Must be done before setup-node.
       - name: Enable Corepack
@@ -63,8 +64,12 @@ jobs:
       - name: Commit and push changes
         if: env.NEW_JSON_FILES
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add records/
-          git commit -m "Process new JSON files from #${{ github.event.pull_request.number }}" || exit 0
-          git push origin HEAD:refs/heads/main
+          node actions/lib/createCommitOnBranch.mjs \
+            "$GITHUB_REPOSITORY" \
+            "main" \
+            "$(git rev-parse HEAD)" \
+            "$(git diff --diff-filter=d --name-only --format=)" \
+            "$(git diff --diff-filter=D --name-only --format=)" \
+            "Process new JSON files from #${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/actions/lib/createCommitOnBranch.mjs
+++ b/actions/lib/createCommitOnBranch.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+const [,,
+  repo,
+  branch,
+  parentCommitSha,
+  modifiedOrAddedFiles,
+  deletedFiles,
+  commit_title,
+  commit_body,
+] = process.argv;
+
+console.log({
+  repo,
+  branch,
+  parentCommitSha,
+  commit_title,
+  commit_body,
+  modifiedOrAddedFiles,
+  deletedFiles,
+});
+
+import { readFileSync } from 'node:fs';
+import util from 'node:util';
+
+const query = `
+mutation ($repo: String! $branch: String!, $parentCommitSha: GitObjectID!, $changes: FileChanges!, $commit_title: String!, $commit_body: String) {
+  createCommitOnBranch(input: {
+    branch: {
+      repositoryNameWithOwner: $repo,
+      branchName: $branch
+    },
+    message: {
+      headline: $commit_title,
+      body: $commit_body
+    },
+    expectedHeadOid: $parentCommitSha,
+    fileChanges: $changes
+  }) {
+    commit {
+      url
+    }
+  }
+}
+`;
+const response = await fetch(process.env.GITHUB_GRAPHQL_URL, {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${process.env.GH_TOKEN}`,
+  },
+  body: JSON.stringify({
+    query,
+    variables: {
+      repo,
+      branch,
+      parentCommitSha,
+      commit_title,
+      commit_body,
+      changes: {
+        additions: modifiedOrAddedFiles.split('\n').filter(Boolean)
+          .map(path => ({ path, contents: readFileSync(path).toString('base64') })),
+        deletions: deletedFiles.split('\n').filter(Boolean).map(path => ({ path })),
+      }
+    },
+  })
+});
+if (!response.ok) {
+  console.log({statusCode: response.status, statusText: response.statusText});
+  process.exitCode ||= 1;
+}
+const data = await response.json();
+if (data.errors?.length) {
+  throw new Error('Endpoint returned an error', { cause: data });
+}
+console.log(util.inspect(data, { depth: Infinity }));


### PR DESCRIPTION
If we care about restricting `git push` in the workflow and create a signed commit, we can use a GraphQL API call instead of `git push`.

I've tested it with https://github.com/TestOrgPleaseIgnore/bluesky/actions/runs/12287645499/job/34290039602, which created https://github.com/TestOrgPleaseIgnore/bluesky/commit/b10d255dc8d7df71cda4f740bb0594bff9c28882