### PR TITLE
fix: validation of PRs from forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           persist-credentials: false
 
       # Must be done before setup-node.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       # Must be done before setup-node.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,10 +1,13 @@
 name: Validate newly added JSON
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
+
+permissions:
+  contents: read
 
 jobs:
   validate-json:
@@ -15,10 +18,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       # Must be done before setup-node.
       - name: Enable Corepack
         run: corepack enable
+
+      # We are using `pull_request_target`, meaning untrusted code could access the secrets.
+      # For PRs from forks, we want to rollback to the trusted version of `actions/`. Other
+      # directories do not contain any runnable code.
+      - if: github.event.pull_request.head.repo.full_name != github.repository
+        run: git checkout HEAD^ -- actions/
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
By switching from `pull_request` event to `pull_request_target`, the workflow would have access to repo secrets. This should allow proper validation for PRs opened from a fork.

This does come with more risks of leaking something, so I added a few protection mechanisms, and for extra piece of mind, I would recommend changing the setting below to the stricter "Require approval for all external contributors".

<img width="783" alt="image" src="https://github.com/user-attachments/assets/9b7f466e-d21c-469e-9075-945de38f7fb3" />
