### PR TITLE
fix: only run `validate` workflow when there are records to validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,8 @@ on:
       - ready_for_review
       - reopened
       - synchronize
+    paths:
+      - records/new/*.json
 
 permissions:
   contents: read


### PR DESCRIPTION
Refs: https://github.com/nodejs/bluesky/pull/31#pullrequestreview-2519157729