### PR TITLE
chore(CODEOWNERS): introduce

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nodejs/bluesky


### PR DESCRIPTION
Add `CODEOWNERS` allow people from outside of the org to know who maintain this part of the nodejs project.
And it's also automatically request review from the team when a pr is opened.