### PR TITLE
Use pull_request in validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,7 @@
 name: Validate newly added JSON
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - ready_for_review


### PR DESCRIPTION
See https://github.com/nodejs/bluesky/pull/55 - using pull_request_target would allow the workflow to run without authorization. While there are some code in this workflow to defend against naive attacks e.g. adding scripts to the actions, there could be other attack vectors e.g. via specially crafted branch names or file names that evade GitHub's escape rules. It would be too hard to wrap our head around this, so the easiest way to defend against it would be to restrict full validation that require access to secrets to PRs opened from branches in this repo.

For PRs opened from forks, I think we should go back to what I proposed in https://github.com/nodejs/bluesky/issues/10 - that is, only run local validations that require no access to secrets, and use `pull_request` for it.

cc @aduh95 @nodejs/tsc