### PR TITLE
chore(ci): add `persist-credentials: false` to `pr-labeler`

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Label pull request
         uses: actions/labeler@v5


### PR DESCRIPTION
The less permissions the better