### PR TITLE
Use persist-credentials: false in pr labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Label pull request
         uses: actions/labeler@v5


### PR DESCRIPTION
I am not sure how much safer it is after this, in any case I already disabled it.